### PR TITLE
Cross out HDF5

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,7 @@ You can jump right into editing this file [here](https://github.com/not-yet-awes
 ## Data processing
 
 * DDS library [wiki](https://en.wikipedia.org/wiki/Data_Distribution_Service)
-* [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) (see also [Wikipedia](https://support.hdfgroup.org/HDF5/) and [this Reddit post](https://www.reddit.com/r/rust/comments/7r30r3/maintained_crate_for_hdf5_bindings/))
-    * The following crates exist, but are missing some thing(s):
-        * [`hdf5-rs`](https://crates.io/crates/hdf5-rs) has a lot of functionality, but is currently in design flux and has an [issue](https://github.com/aldanor/hdf5-rs/issues/17) reporting its status.
-        * [`hdf5`](https://crates.io/crates/hdf5) seems capable of writing HDF5-encoded data, but not reading it.
+* ~~[HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) (see also [Wikipedia](https://support.hdfgroup.org/HDF5/) and [this Reddit post](https://www.reddit.com/r/rust/comments/7r30r3/maintained_crate_for_hdf5_bindings/))~~ A stable version of [`hdf5`](https://github.com/aldanor/hdf5-rust) crate has been released and is now [available](https://crates.io/crates/hdf5) on crates.io.
 * A good stream processing pipeline with back pressure doesn't yet exist for an asynchronous data processing pipeline
     * [RxRust](https://github.com/ReactiveX/RxRust) is an older attempt to implement this according to the [reactive streams](http://www.reactive-streams.org/#the-problem) model -- it currently seems closest to this use case.
     * [`tokio`](https://github.com/tokio-rs/tokio) and [`futures`]() may be interesting components to use when building this.


### PR DESCRIPTION
Crossing out HDF5 since we've released a stable version of the crate (after it was in 'design flux' for quite a while).