### PR TITLE
fix(xml): s/RazrFalcon/tafia

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,4 +216,4 @@ There is yet to be a library that handles all of these:
 * Option to preserve input style
 * Is *fast*
 
-For more feature and performance comparisons for existing Rust XML crates, see [`choose-your-xml-rs`](https://github.com/RazrFalcon/choose-your-xml-rs).
+For more feature and performance comparisons for existing Rust XML crates, see [`choose-your-xml-rs`](https://github.com/tafia/choose-your-xml-rs).


### PR DESCRIPTION
Uses @tafia's list for comparing XML crates, instead of @RazrFalcon's now-defunct one.